### PR TITLE
♻️ Make Script Portable With `#!/usr/bin/env` As a Shebang

### DIFF
--- a/safe_hashes.sh
+++ b/safe_hashes.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ########################
 # Don't trust, verify! #


### PR DESCRIPTION
### 🕓 Changelog

This PR changes the interpreter directive (shebang) line to use `/usr/bin/env bash` as an interpreter instead of `/bin/bash`. This allows to use a correct version of Bash regardless of how it's installed by making the `env` command look up the `bash` executable in the `PATH` before running it (as explained e.g. [here](https://www.cyberciti.biz/tips/finding-bash-perl-python-portably-using-env.html)).

Fixes running the script under a non-root Homebrew setup where Bash 4 is installed under `/opt/homebrew/bin/` with the latter directory added to `PATH`.