### PR TITLE
✨ Add Support for Domain Hash Logic in Safe Versions `<= 1.2.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This Bash [script](./safe_hashes.sh) calculates the Safe transaction hashes by r
 > This Bash [script](./safe_hashes.sh) relies on the [Safe transaction service API](https://docs.safe.global/core-api/transaction-service-overview), which requires transactions to be proposed and _logged_ in the service before they can be retrieved. Consequently, the initial transaction proposer cannot access the transaction at the proposal stage, making this approach incompatible with 1-of-1 multisigs.
 
 > [!IMPORTANT]
-> All Safe versions starting from `1.0.0` and newer are supported.
+> All Safe multisig versions starting from `1.0.0` and newer are supported.
 
 ## Supported Networks
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This Bash [script](./safe_hashes.sh) calculates the Safe transaction hashes by r
 > This Bash [script](./safe_hashes.sh) relies on the [Safe transaction service API](https://docs.safe.global/core-api/transaction-service-overview), which requires transactions to be proposed and _logged_ in the service before they can be retrieved. Consequently, the initial transaction proposer cannot access the transaction at the proposal stage, making this approach incompatible with 1-of-1 multisigs.
 
 > [!IMPORTANT]
-> All Safe versions starting from 1.0.0 and newer are supported.
+> All Safe versions starting from `1.0.0` and newer are supported.
 
 ## Supported Networks
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ This Bash [script](./safe_hashes.sh) calculates the Safe transaction hashes by r
 > [!NOTE]
 > This Bash [script](./safe_hashes.sh) relies on the [Safe transaction service API](https://docs.safe.global/core-api/transaction-service-overview), which requires transactions to be proposed and _logged_ in the service before they can be retrieved. Consequently, the initial transaction proposer cannot access the transaction at the proposal stage, making this approach incompatible with 1-of-1 multisigs.
 
+> [!IMPORTANT]
+> All Safe versions starting from 1.0.0 and newer are supported.
+
 ## Supported Networks
 
 - Arbitrum (identifier: `arbitrum`, chain ID: `42161`)

--- a/safe_hashes.sh
+++ b/safe_hashes.sh
@@ -248,11 +248,11 @@ calculate_hashes() {
     local domain_separator_typehash="$DOMAIN_SEPARATOR_TYPEHASH"
     local domain_hash_args="$domain_separator_typehash, $chain_id, $address"
 
-    # Safe versions can have the format `X.Y.Z+L2`.
+    # Safe multisig versions can have the format `X.Y.Z+L2`.
     # Remove any suffix after and including the `+` in the version string for comparison.
-    clean_version=$(echo "$version" | sed 's/+.*//')
+    clean_version=$(echo "$version" | sed "s/+.*//")
 
-    # Safe versions `<= 1.2.0` use a legacy (i.e. without `chainId`) `DOMAIN_SEPARATOR_TYPEHASH` value.
+    # Safe multisig versions `<= 1.2.0` use a legacy (i.e. without `chainId`) `DOMAIN_SEPARATOR_TYPEHASH` value.
     # Starting with version `1.3.0`, the `chainId` field was introduced: https://github.com/safe-global/safe-smart-account/pull/264.
     if [[ "$(printf "%s\n%s" "$clean_version" "1.2.0" | sort -V | head -n1)" == "$clean_version" ]]; then
         domain_separator_typehash="$DOMAIN_SEPARATOR_TYPEHASH_OLD"

--- a/safe_hashes.sh
+++ b/safe_hashes.sh
@@ -42,7 +42,7 @@ readonly RESET="\e[0m"
 # See: https://github.com/safe-global/safe-smart-account/blob/a0a1d4292006e26c4dbd52282f4c932e1ffca40f/contracts/Safe.sol#L54-L57.
 readonly DOMAIN_SEPARATOR_TYPEHASH="0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218"
 # => `keccak256("EIP712Domain(address verifyingContract)");`
-# See: https://github.com/safe-global/safe-smart-account/blob/v1.0.0/contracts/GnosisSafe.sol#L20-L23.
+# See: https://github.com/safe-global/safe-smart-account/blob/703dde2ea9882a35762146844d5cfbeeec73e36f/contracts/GnosisSafe.sol#L20-L23.
 readonly DOMAIN_SEPARATOR_TYPEHASH_OLD="0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749"
 # => `keccak256("SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)");`
 # See: https://github.com/safe-global/safe-smart-account/blob/a0a1d4292006e26c4dbd52282f4c932e1ffca40f/contracts/Safe.sol#L59-L62.

--- a/safe_hashes.sh
+++ b/safe_hashes.sh
@@ -41,6 +41,9 @@ readonly RESET="\e[0m"
 # => `keccak256("EIP712Domain(uint256 chainId,address verifyingContract)");`
 # See: https://github.com/safe-global/safe-smart-account/blob/a0a1d4292006e26c4dbd52282f4c932e1ffca40f/contracts/Safe.sol#L54-L57.
 readonly DOMAIN_SEPARATOR_TYPEHASH="0x47e79534a245952e8b16893a336b85a3d9ea9fa8c573f3d803afb92a79469218"
+# => `keccak256("EIP712Domain(address verifyingContract)");`
+# See: https://github.com/safe-global/safe-smart-account/blob/v1.0.0/contracts/GnosisSafe.sol#L20-L23.
+readonly DOMAIN_SEPARATOR_TYPEHASH_OLD="0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749"
 # => `keccak256("SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)");`
 # See: https://github.com/safe-global/safe-smart-account/blob/a0a1d4292006e26c4dbd52282f4c932e1ffca40f/contracts/Safe.sol#L59-L62.
 readonly SAFE_TX_TYPEHASH="0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8"
@@ -240,9 +243,24 @@ calculate_hashes() {
     local refund_receiver=${11}
     local nonce=${12}
     local data_decoded=${13}
+    local version=${14}
+
+    local domain_separator_typehash="$DOMAIN_SEPARATOR_TYPEHASH"
+    local domain_hash_args="$domain_separator_typehash, $chain_id, $address"
+
+    # Safe versions can have the format `X.Y.Z+L2`.
+    # Remove any suffix after and including the `+` in the version string for comparison.
+    clean_version=$(echo "$version" | sed 's/+.*//')
+
+    # Safe versions `<= 1.2.0` use a legacy (i.e. without `chainId`) `DOMAIN_SEPARATOR_TYPEHASH` value.
+    # Starting with version `1.3.0`, the `chainId` field was introduced: https://github.com/safe-global/safe-smart-account/pull/264.
+    if [[ "$(printf "%s\n%s" "$clean_version" "1.2.0" | sort -V | head -n1)" == "$clean_version" ]]; then
+        domain_separator_typehash="$DOMAIN_SEPARATOR_TYPEHASH_OLD"
+        domain_hash_args="$domain_separator_typehash, $address"
+    fi
 
     # Calculate the domain hash.
-    local domain_hash=$(chisel eval "keccak256(abi.encode($DOMAIN_SEPARATOR_TYPEHASH, $chain_id, $address))" |
+    local domain_hash=$(chisel eval "keccak256(abi.encode($domain_hash_args))" |
         awk '/Data:/ {gsub(/\x1b\[[0-9;]*m/, "", $3); print $3}')
 
     # Calculate the data hash.
@@ -354,7 +372,7 @@ calculate_safe_tx_hashes() {
     local endpoint="${api_url}/api/v1/safes/${address}/multisig-transactions/?nonce=${nonce}"
 
     # Fetch the transaction data from the API.
-    local response=$(curl -s "$endpoint")
+    local response=$(curl -sf "$endpoint")
     local count=$(echo "$response" | jq -r ".count // \"0\"")
     local idx=0
 
@@ -411,6 +429,9 @@ EOF
     local nonce=$(echo "$response" | jq -r ".results[$idx].nonce // \"0\"")
     local data_decoded=$(echo "$response" | jq -r ".results[$idx].dataDecoded // \"0x\"")
 
+    # Get the Safe version.
+    local version=$(curl -sf "${api_url}/api/v1/safes/${address}/" | jq -r ".version // \"0.0.0\"")
+
     # Calculate and display the hashes.
     echo "==================================="
     echo "= Selected Network Configurations ="
@@ -432,7 +453,8 @@ EOF
         "$gas_token" \
         "$refund_receiver" \
         "$nonce" \
-        "$data_decoded"
+        "$data_decoded" \
+        "$version"
 }
 
 calculate_safe_tx_hashes "$@"

--- a/safe_hashes.sh
+++ b/safe_hashes.sh
@@ -429,7 +429,7 @@ EOF
     local nonce=$(echo "$response" | jq -r ".results[$idx].nonce // \"0\"")
     local data_decoded=$(echo "$response" | jq -r ".results[$idx].dataDecoded // \"0x\"")
 
-    # Get the Safe version.
+    # Get the Safe multisig version.
     local version=$(curl -sf "${api_url}/api/v1/safes/${address}/" | jq -r ".version // \"0.0.0\"")
 
     # Calculate and display the hashes.


### PR DESCRIPTION
### 🕓 Changelog

Safe versions `<= 1.2.0` use a legacy (i.e. without `chainId`) [`DOMAIN_SEPARATOR_TYPEHASH`](https://github.com/safe-global/safe-smart-account/blob/v1.0.0/contracts/GnosisSafe.sol#L20-L23) value:
```solidity
//keccak256(
//    "EIP712Domain(address verifyingContract)"
//);
bytes32 public constant DOMAIN_SEPARATOR_TYPEHASH = 0x035aff83d86937d35b32e04f0ddc6ff469290eef2f1b692d8a815c89404d4749;
```

Starting with version [`1.3.0`](https://github.com/safe-global/safe-smart-account/releases/tag/v1.3.0), the `chainId` field was introduced: https://github.com/safe-global/safe-smart-account/pull/264.

This PR introduces additional logic to the script to accommodate the breaking change in Safe versions. Please note that the Safe UI currently displays the wrong domain hash (see my [issue](https://github.com/safe-global/safe-wallet-web/issues/4613)) for Safe versions `<= 1.2.0`.

### Testing

**Ethereum:**

The Safe multisig [`0x2a2D6e4919FF1519E3D7EDe8E44164025654bCe3`](https://etherscan.io/address/0x2a2D6e4919FF1519E3D7EDe8E44164025654bCe3) is based on version [`1.1.1`](https://github.com/safe-global/safe-smart-account/releases/tag/v1.1.1).

Run:

```console
./safe_hashes.sh --network ethereum --address 0x2a2D6e4919FF1519E3D7EDe8E44164025654bCe3 --nonce 96
```

```console
> Hashes:
Domain hash: 0xC85EA7830A5F1CA230FCF8985B847DB8478D1418D5775C694E73E2C6929C0BF7
Message hash: 0x94FB2C1ADA06B1E630E0C0F101F772860A9B2215BE038AD9A16CD4CAE2010DCE
Safe transaction hash: 0x2ba61caa296cebd7a132ac1f1dbd9df1dc9e3fee4dc79434be08966ecec2f11c
```

and compare with: https://app.safe.global/transactions/tx?safe=eth:0x2a2D6e4919FF1519E3D7EDe8E44164025654bCe3&id=multisig_0x2a2D6e4919FF1519E3D7EDe8E44164025654bCe3_0x2ba61caa296cebd7a132ac1f1dbd9df1dc9e3fee4dc79434be08966ecec2f11c

![image](https://github.com/user-attachments/assets/c5f0ce83-ea45-48ea-8016-536992e9631f)

Due to the current [issue](https://github.com/safe-global/safe-wallet-web/issues/4613), the domain hash displayed in the Safe UI is wrong. We can verify it using `cast` nonetheless:

```console
cast call 0x2a2D6e4919FF1519E3D7EDe8E44164025654bCe3 "domainSeparator()" -r https://eth.llamarpc.com
```

which outputs:

```console
0xc85ea7830a5f1ca230fcf8985b847db8478d1418d5775c694e73e2c6929c0bf7
```

**Gnosis:**

The Safe multisig [`0x12eCe7B282F4aec608B107A5666B64Fbb10A6EE5`](https://gnosisscan.io/address/0x12eCe7B282F4aec608B107A5666B64Fbb10A6EE5) is based on version [`1.0.0`](https://github.com/safe-global/safe-smart-account/releases/tag/v1.0.0).

```console
./safe_hashes.sh --network gnosis --address 0x12eCe7B282F4aec608B107A5666B64Fbb10A6EE5 --nonce 2
```

```console
> Hashes:
Domain hash: 0x8FA78DB2CDF3A0E9834D1963562A5EBAD20354303365F4982744BE746C0075EE
Message hash: 0x13FEB76C22828543BD6EF67AB4404F21FC8426584D38B32261D9824D8D12D209
Safe transaction hash: 0x6ac0d1c42bbfef85b2ed94f0dfb68c5b223c6cc9e4e93bd83f6007e826c81be3
```

and compare with: https://app.safe.global/transactions/tx?safe=gno:0x12eCe7B282F4aec608B107A5666B64Fbb10A6EE5&id=multisig_0x12eCe7B282F4aec608B107A5666B64Fbb10A6EE5_0x6ac0d1c42bbfef85b2ed94f0dfb68c5b223c6cc9e4e93bd83f6007e826c81be3

![image](https://github.com/user-attachments/assets/973ae48d-77ac-4fa7-8f96-a2d4b31ded14)

Due to the current [issue](https://github.com/safe-global/safe-wallet-web/issues/4613), the domain hash displayed in the Safe UI is wrong. We can verify it using `cast`:

```console
cast call 0x12eCe7B282F4aec608B107A5666B64Fbb10A6EE5 "domainSeparator()" -r https://rpc.ankr.com/gnosis
```

which outputs:

```console
0x8fa78db2cdf3a0e9834d1963562a5ebad20354303365f4982744be746c0075ee
```