### PR TITLE
📖 Clarify `README` Instructions for Apple Silicon vs Intel Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ This Bash [script](./safe_hashes.sh) calculates the Safe transaction hashes by r
 - [Supported Networks](#supported-networks)
 - [Usage](#usage)
   - [macOS Users: Upgrading Bash](#macos-users-upgrading-bash)
+    - [Optional: Set the New Bash as Your Default Shell](#optional-set-the-new-bash-as-your-default-shell)
 - [Safe Transaction Hashes](#safe-transaction-hashes)
 - [Safe Message Hashes](#safe-message-hashes)
 - [Trust Assumptions](#trust-assumptions)
@@ -98,23 +99,40 @@ This [script](./safe_hashes.sh) requires Bash [`4.0`](https://tldp.org/LDP/abs/h
 brew install bash
 ```
 
-3. Add the new shell to the list of allowed shells:
+3. Verify you have at least version 4.0 or higher of bash
+
+```bash
+bash --version
+```
+
+#### Optional: Set the New Bash as Your Default Shell
+
+1. Get your bash path (`BASH_PATH`)
+
+```bash
+which bash
+```
+
+2. Add the new shell to the list of allowed shells:
+
+It's usually either:
 
 ```console
 sudo bash -c 'echo /usr/local/bin/bash >> /etc/shells'
 ```
 
-4. Optionally, make it your default shell:
+or
 
 ```console
-chsh -s /usr/local/bin/bash
+sudo bash -c 'echo /opt/homebrew/bin/bash >> /etc/shells'
 ```
 
-You can verify your Bash version after the installation:
+3. Make it your default shell:
 
 ```console
-bash --version
+chsh -s BASH_PATH
 ```
+
 
 ## Safe Transaction Hashes
 

--- a/README.md
+++ b/README.md
@@ -99,40 +99,43 @@ This [script](./safe_hashes.sh) requires Bash [`4.0`](https://tldp.org/LDP/abs/h
 brew install bash
 ```
 
-3. Verify you have at least version 4.0 or higher of bash
+3. Verify that you are using Bash version `4.0` or higher:
 
-```bash
+```console
 bash --version
 ```
 
 #### Optional: Set the New Bash as Your Default Shell
 
-1. Get your bash path (`BASH_PATH`)
+1. Find the path to your Bash installation (`BASH_PATH`):
 
-```bash
+```console
 which bash
 ```
 
 2. Add the new shell to the list of allowed shells:
 
-It's usually either:
+Depending on your Mac's architecture and where [Homebrew](https://brew.sh) installs Bash, you will use one of the following commands:
 
 ```console
+# For Intel-based Macs or if Homebrew is installed in the default location.
 sudo bash -c 'echo /usr/local/bin/bash >> /etc/shells'
 ```
 
 or
 
 ```console
+# For Apple Silicon (M1/M2) Macs or if you installed Homebrew using the default path for Apple Silicon.
 sudo bash -c 'echo /opt/homebrew/bin/bash >> /etc/shells'
 ```
 
-3. Make it your default shell:
+3. Set the new Bash as your default shell:
 
 ```console
 chsh -s BASH_PATH
 ```
 
+Make sure to replace `BASH_PATH` with the actual path you retrieved in step 1.
 
 ## Safe Transaction Hashes
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ This [script](./safe_hashes.sh) requires Bash [`4.0`](https://tldp.org/LDP/abs/h
 brew install bash
 ```
 
-3. Verify that you are using Bash version `4.0` or higher:
+3. Verify that you are using Bash version [`4.0`](https://tldp.org/LDP/abs/html/bashver4.html) or higher:
 
 ```console
 bash --version

--- a/safe_hashes.sh
+++ b/safe_hashes.sh
@@ -149,7 +149,7 @@ Example for transaction hashes:
 Example for off-chain message hashes:
   $0 --network ethereum --address 0x1234...5678 --message message.txt
 EOF
-    exit 1
+    exit "${1:-1}"
 }
 
 # Utility function to list all supported networks.
@@ -177,7 +177,7 @@ print_header() {
 print_field() {
     local label=$1
     local value=$2
-    local empty_line=${3:-false}
+    local empty_line="${3:-false}"
 
     if [[ -t 1 ]] && tput sgr0 >/dev/null 2>&1; then
         # Terminal supports formatting.
@@ -503,7 +503,7 @@ calculate_offchain_message_hashes() {
 #    - Extracts the relevant transaction details from the API response.
 #    - Calls the `calculate_hashes` function to compute and display the results.
 calculate_safe_hashes() {
-    # Show help if no arguments are provided
+    # Display the help message if no arguments are provided.
     if [[ $# -eq 0 ]]; then
         usage
     fi
@@ -513,7 +513,7 @@ calculate_safe_hashes() {
     # Parse the command line arguments.
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --help) usage ;;
+            --help) usage 0 ;;
             --network) network="$2"; shift 2 ;;
             --address) address="$2"; shift 2 ;;
             --nonce) nonce="$2"; shift 2 ;;

--- a/safe_hashes.sh
+++ b/safe_hashes.sh
@@ -503,6 +503,11 @@ calculate_offchain_message_hashes() {
 #    - Extracts the relevant transaction details from the API response.
 #    - Calls the `calculate_hashes` function to compute and display the results.
 calculate_safe_hashes() {
+    # Show help if no arguments are provided
+    if [[ $# -eq 0 ]]; then
+        usage
+    fi
+
     local network="" address="" nonce="" message_file=""
 
     # Parse the command line arguments.


### PR DESCRIPTION
### 🕓 Changelog

This PR introduces the following changes:
1. Clarifies that Apple Silicon Macs use a different path for Homebrew-installed Bash (`/opt/homebrew/bin/bash`).
2. Updates the instructions to specify that adding Bash to the list of allowed shells in `/etc/shells` is only necessary for setting it as the default shell.
3. Adds a `help` option to display usage instructions when no arguments are provided.