### PR TITLE
♻️ Use `stdin` to Hash Large Data Inputs

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -82,4 +82,4 @@ jobs:
         run: gem install awesome_bot
 
       - name: Validate URLs
-        run: awesome_bot ./*.md ./*.sh --allow-dupe --request-delay 0.4 --white-list https://opensea.io,https://linux.die.net/man/1/tput
+        run: awesome_bot ./*.md ./*.sh --allow-dupe --request-delay 0.4 --white-list https://opensea.io,https://linux.die.net/man/1/tput,https://etherscan.io

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This Bash [script](./safe_hashes.sh) calculates the Safe transaction hashes by r
 ## Usage
 
 > [!NOTE]
-> Ensure that [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) and [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel) are installed locally. For installation instructions, refer to this [guide](https://book.getfoundry.sh/getting-started/installation). This [script](./safe_hashes.sh) is designed to work with the latest _stable_ versions of [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) and [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel), starting from version [`1.2.2`](https://github.com/foundry-rs/foundry/releases/tag/v1.2.2).
+> Ensure that [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) and [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel) are installed locally. For installation instructions, refer to this [guide](https://book.getfoundry.sh/introduction/installation). This [script](./safe_hashes.sh) is designed to work with the latest _stable_ versions of [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) and [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel), starting from version [`1.2.2`](https://github.com/foundry-rs/foundry/releases/tag/v1.2.2).
 
 > [!TIP]
 > For macOS users, please refer to the [macOS Users: Upgrading Bash](#macos-users-upgrading-bash) section.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This Bash [script](./safe_hashes.sh) calculates the Safe transaction hashes by r
 ## Usage
 
 > [!NOTE]
-> Ensure that [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) and [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel) are installed locally. For installation instructions, refer to this [guide](https://book.getfoundry.sh/getting-started/installation).
+> Ensure that [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) and [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel) are installed locally. For installation instructions, refer to this [guide](https://book.getfoundry.sh/getting-started/installation). This [script](./safe_hashes.sh) is designed to work with the latest _stable_ versions of [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) and [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel).
 
 > [!TIP]
 > For macOS users, please refer to the [macOS Users: Upgrading Bash](#macos-users-upgrading-bash) section.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This Bash [script](./safe_hashes.sh) calculates the Safe transaction hashes by r
 ## Usage
 
 > [!NOTE]
-> Ensure that [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) and [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel) are installed locally. For installation instructions, refer to this [guide](https://book.getfoundry.sh/getting-started/installation). This [script](./safe_hashes.sh) is designed to work with the latest _stable_ versions of [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) and [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel).
+> Ensure that [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) and [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel) are installed locally. For installation instructions, refer to this [guide](https://book.getfoundry.sh/getting-started/installation). This [script](./safe_hashes.sh) is designed to work with the latest _stable_ versions of [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) and [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel), starting from version [`1.2.2`](https://github.com/foundry-rs/foundry/releases/tag/v1.2.2).
 
 > [!TIP]
 > For macOS users, please refer to the [macOS Users: Upgrading Bash](#macos-users-upgrading-bash) section.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This Bash [script](./safe_hashes.sh) calculates the Safe transaction hashes by r
 ## Usage
 
 > [!NOTE]
-> Ensure that [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) and [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel) are installed locally. For installation instructions, refer to this [guide](https://book.getfoundry.sh/introduction/installation). This [script](./safe_hashes.sh) is designed to work with the latest _stable_ versions of [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) and [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel), starting from version [`1.2.2`](https://github.com/foundry-rs/foundry/releases/tag/v1.2.2).
+> Ensure that [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) and [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel) are installed locally. For installation instructions, refer to this [guide](https://book.getfoundry.sh/introduction/installation/). This [script](./safe_hashes.sh) is designed to work with the latest _stable_ versions of [`cast`](https://github.com/foundry-rs/foundry/tree/master/crates/cast) and [`chisel`](https://github.com/foundry-rs/foundry/tree/master/crates/chisel), starting from version [`1.2.2`](https://github.com/foundry-rs/foundry/releases/tag/v1.2.2).
 
 > [!TIP]
 > For macOS users, please refer to the [macOS Users: Upgrading Bash](#macos-users-upgrading-bash) section.

--- a/safe_hashes.sh
+++ b/safe_hashes.sh
@@ -737,7 +737,7 @@ calculate_offchain_message_hashes() {
 
 	local message_raw=$(<"$message_file")
 	# Normalise line endings to `LF` (`\n`).
-	message_raw=$(echo "$message_raw" | tr -d "\r")
+	message_raw=$(printf "%s" "$message_raw" | tr -d "\r")
 	local hashed_message=$(printf "%s" "$message_raw" | cast hash-message)
 
 	local domain_separator_typehash="$DOMAIN_SEPARATOR_TYPEHASH"
@@ -790,7 +790,7 @@ calculate_nested_safe_offchain_message_hashes() {
 
 	local message_raw=$(<"$message_file")
 	# Normalise line endings to `LF` (`\n`).
-	message_raw=$(echo "$message_raw" | tr -d "\r")
+	message_raw=$(printf "%s" "$message_raw" | tr -d "\r")
 	local hashed_message=$(printf "%s" "$message_raw" | cast hash-message)
 
 	local domain_separator_typehash="$DOMAIN_SEPARATOR_TYPEHASH"

--- a/safe_hashes.sh
+++ b/safe_hashes.sh
@@ -514,7 +514,7 @@ calculate_hashes() {
 	# Calculate the data hash.
 	# The dynamic value `bytes` is encoded as a `keccak256` hash of its content.
 	# See: https://eips.ethereum.org/EIPS/eip-712#definition-of-encodedata.
-	local data_hashed=$(cast keccak "$data")
+	local data_hashed=$(printf "%s" "$data" | cast keccak)
 
 	# Safe multisig versions `< 1.0.0` use a legacy (i.e. the parameter value `baseGas` was
 	# called `dataGas` previously) `SAFE_TX_TYPEHASH` value. Starting with version `1.0.0`,
@@ -738,7 +738,7 @@ calculate_offchain_message_hashes() {
 	local message_raw=$(<"$message_file")
 	# Normalise line endings to `LF` (`\n`).
 	message_raw=$(echo "$message_raw" | tr -d "\r")
-	local hashed_message=$(cast hash-message "$message_raw")
+	local hashed_message=$(printf "%s" "$message_raw" | cast hash-message)
 
 	local domain_separator_typehash="$DOMAIN_SEPARATOR_TYPEHASH"
 	local domain_hash_args="$domain_separator_typehash, $chain_id, $address"
@@ -791,7 +791,7 @@ calculate_nested_safe_offchain_message_hashes() {
 	local message_raw=$(<"$message_file")
 	# Normalise line endings to `LF` (`\n`).
 	message_raw=$(echo "$message_raw" | tr -d "\r")
-	local hashed_message=$(cast hash-message "$message_raw")
+	local hashed_message=$(printf "%s" "$message_raw" | cast hash-message)
 
 	local domain_separator_typehash="$DOMAIN_SEPARATOR_TYPEHASH"
 	local domain_hash_args="$domain_separator_typehash, $chain_id, $nested_safe_address"


### PR DESCRIPTION
### 🕓 Changelog

This PR fixes the `Argument list too long` errors (see, e.g., [here](https://github.com/foundry-rs/foundry/issues/10659)) by piping the (potentially very) large inputs to `cast keccak` and `cast hash-message` via `stdin` instead of passing it as a command-line argument. Please note that this PR relies on the patch for `cast hash-message` introduced in [foundry-rs/foundry#10671](https://github.com/foundry-rs/foundry/pull/10671), included in Foundry [`1.2.2`](https://github.com/foundry-rs/foundry/releases/tag/v1.2.2) and available in the latest _stable_ release of `cast`.

### Test Example

```console
./safe_hashes.sh --network zksync --address 0x9fb5F754f5222449F98b904a34494cB21AADFdf8 --nonce 12
```

> Select `1` for "Please enter the index of the array:".

returns:

```console
===================================
= Selected Network Configurations =
===================================

Network: zksync
Chain ID: 324

========================================
= Transaction Data and Computed Hashes =
========================================

> Transaction Data:
Multisig address: 0x9fb5F754f5222449F98b904a34494cB21AADFdf8
To: 0xCC926359DBE6b6311D63f8155fcC3B57F3fAAE80
Value: 0
Data: 0x... (very large; omitted here)
Operation: Call
Safe Transaction Gas: 0
Base Gas: 0
Gas Price: 0
Gas Token: 0x0000000000000000000000000000000000000000
Refund Receiver: 0x0000000000000000000000000000000000000000
Nonce: 12
Encoded message: 0xbb8310d486368db6bd6f849402fdd73ad53d316b5a4b2644ad6efe0f941286d8000000000000000000000000cc926359dbe6b6311d63f8155fcc3b57f3faae800000000000000000000000000000000000000000000000000000000000000000390de467d7c8f2ce53221c9e9b8961d6f95a9bac95c8d64860569536e2530d7f000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c
Method: Unknown
Parameters: Unknown

> Hashes:
Domain hash: 0x44B7F5D3633D89B36226C7C3FE506E64904143C6289D42E5EAE52EAB28D1B034
Message hash: 0x5FF90C7690C66DE45D4D84AE5BE2F7D4722E6236DBEB223B9450F7FC28ADA78D
Safe transaction hash: 0x8bf43f38a201cef8317d773de616d0dc75115c84d83fad4388f691cc00acd538
```

Now compare with https://app.safe.global/transactions/tx?safe=zksync:0x9fb5F754f5222449F98b904a34494cB21AADFdf8&id=multisig_0x9fb5F754f5222449F98b904a34494cB21AADFdf8_0x8bf43f38a201cef8317d773de616d0dc75115c84d83fad4388f691cc00acd538.

This PR also adds `https://etherscan.io` to the `awesome_bot` whitelist in the CI pipeline `checks.yml`.