### PR TITLE
♻️ Enforce EIP-55 Checksums for Addresses

### DIFF
--- a/safe_hashes.sh
+++ b/safe_hashes.sh
@@ -779,7 +779,7 @@ validate_address() {
 	local checksum=$(cast to-check-sum-address "$address")
 	if [[ "$address" != "$checksum" ]]; then
 		echo -e "${BOLD}${RED}Invalid checksum: \"$address\" (expected \"${checksum}\")${RESET}" >&2
-		return 1
+		exit 1
 	fi
 }
 


### PR DESCRIPTION
### 🕓 Changelog

This PR updates the `validate_address` function to enforce [EIP-55](https://eips.ethereum.org/EIPS/eip-55) checksummed addresses. This ensures that all addresses submitted to the [Safe transaction service API](https://docs.safe.global/core-api/transaction-service-overview) are correctly checksummed, preventing potential API errors caused by incorrectly-cased addresses. Furthermore, we redirect all error messages in the functions `check_required_tools`, `get_latest_git_commit_hash`, and the Bash version check to `stderr` for proper error handling.

### Test Examples

#### Test Case 1

```console
./safe_hashes.sh --network sepolia --address 0x657FF0D4EC65D82B2BC1247B0A558BCD2F80A0F1 --nonce 4
```

returns:

```console
Invalid checksum: "0x657FF0D4EC65D82B2BC1247B0A558BCD2F80A0F1" (expected "0x657ff0D4eC65D82b2bC1247b0a558bcd2f80A0f1")
```

#### Test Case 2

```console
./safe_hashes.sh --network sepolia --address 0x657ff0D4eC65D82b2bC1247b0a558bcd2f80A0f1 --nonce 4 --nested-safe-address 0x6bc56d6ce87c86cb0756c616becfd3cd32b09251 --nested-safe-nonce 4
```

returns:

```console
Invalid checksum: "0x6bc56d6ce87c86cb0756c616becfd3cd32b09251" (expected "0x6bc56d6CE87C86CB0756c616bECFD3Cd32b09251")
```